### PR TITLE
Run Aderyn automatically on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": ["*"],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,9 @@ export function activate(context: vscode.ExtensionContext) {
             diagnosticCollection.delete(document.uri);
             runAderyn(context, aderynOutputChannel, diagnosticCollection, document.uri);
         }
-    })
+    });
+
+    runAderyn(context, aderynOutputChannel, diagnosticCollection);
 
     context.subscriptions.push(runCommand);
     context.subscriptions.push(solidityWatcher);


### PR DESCRIPTION

First change:

Call `runAderyn(..)` in the `activate()` function but I had to do it in order to automatically invoke aderyn on activation
(not sure if it's a good idea)


Second change:

Activation on startup in addition to command pallete
(this is achieved by putting a `*` in activation events in package.json)