### PR TITLE
Feature: Persistent kv store

### DIFF
--- a/src/kvstore.ts
+++ b/src/kvstore.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Mapping value: This fields correspond to the input boxes in the sidebar
+ * which translates roughly to CLI options when running aderyn.
+ */
+export interface ProjectOptions {
+    scope?: string,
+    exclude?: string
+}
+
+/**
+ * Mapping Key: Absolute path to project on the machine
+ */
+export type ProjectPath = string; 
+
+/**
+ * Maintain a persitent mapping from `ProjectPath` to `ProjectOptions`
+ * so that we can auto fill the values in the sidebar if the user has already 
+ * made their preferences clear for a given solidity project
+ */
+export class KVStore {
+    private filePath: string;
+    private data: { [key: ProjectPath]: ProjectOptions };
+
+    constructor(filename: string) {
+        this.filePath = path.join(this.getUserHome(), filename);
+        this.data = {};
+        this.loadFromFile();
+    }
+
+    private loadFromFile(): void {
+        try {
+            const data = fs.readFileSync(this.filePath, 'utf-8');
+            this.data = JSON.parse(data);
+        } catch (err) {
+            this.saveToFile();
+        }
+    }
+
+    private saveToFile(): boolean {
+        try {
+            fs.writeFileSync(this.filePath, JSON.stringify(this.data, null, 2));
+            return true;
+        } catch (err) {
+            return false;
+        }
+    }
+
+    public set(key: string, value: ProjectOptions): void {
+        this.data[key] = value;
+        this.saveToFile();
+    }
+
+    public get(key: string): ProjectOptions {
+        return this.data[key];
+    }
+
+    public delete(key: string): void {
+        delete this.data[key];
+        this.saveToFile();
+    }
+
+    private getUserHome(): string {
+        return process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'] || '';
+    }
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import * as kvstore from '../kvstore';
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
@@ -12,4 +12,17 @@ suite('Extension Test Suite', () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
 	});
+
+	test('Key Value store', () => {
+		const kvStore = new kvstore.KVStore('aderyn-vs-code-tests.json');
+		kvStore.set('/absolute/path/to/project1', {
+			scope: "src/",
+			exclude: "lib/",
+		});
+		assert.strictEqual(kvStore.get('/absolute/path/to/project1').scope, 'src/');
+
+		kvStore.set('/absolute/path/to/project2', {});
+		assert.strictEqual(kvStore.get('/absolute/path/to/project2').scope, undefined);
+	});
+
 });


### PR DESCRIPTION
The motivation for this is as follows:

Sidebar should load cached values for `scope` and `exclude`. Therefore we should have the ability to persist these values in the user's home folder as follows

```bash
cat ~/aderyn-vs-code-tests.json
{
  "/absolute/path/to/project1": {
    "scope": "src/",
    "exclude": "lib/"
  },
  "/absolute/path/to/project2": {}
}
```

This PR gives tools for doing so. (later if sidebar PR is approved, then this might  also make sense)